### PR TITLE
add missing fcntl.h include

### DIFF
--- a/src/xjadeo/mqueue.c
+++ b/src/xjadeo/mqueue.c
@@ -23,6 +23,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <stdarg.h>
 


### PR DESCRIPTION
Systems that use musl-libc will fail to compile with the following error.

```
mqueue.c: In function 'mymq_init':
mqueue.c:58:26: error: 'O_RDONLY' undeclared (first use in this function)
  mqfd_r = mq_open(qname, O_RDONLY | O_CREAT | O_EXCL | O_NONBLOCK, S_IRWXU , NULL);
                          ^~~~~~~~
mqueue.c:58:26: note: each undeclared identifier is reported only once for each function it appears in
mqueue.c:58:37: error: 'O_CREAT' undeclared (first use in this function)
  mqfd_r = mq_open(qname, O_RDONLY | O_CREAT | O_EXCL | O_NONBLOCK, S_IRWXU , NULL);
                                     ^~~~~~~
mqueue.c:58:47: error: 'O_EXCL' undeclared (first use in this function)
  mqfd_r = mq_open(qname, O_RDONLY | O_CREAT | O_EXCL | O_NONBLOCK, S_IRWXU , NULL);
                                               ^~~~~~
mqueue.c:58:56: error: 'O_NONBLOCK' undeclared (first use in this function)
  mqfd_r = mq_open(qname, O_RDONLY | O_CREAT | O_EXCL | O_NONBLOCK, S_IRWXU , NULL);
                                                        ^~~~~~~~~~
mqueue.c:74:26: error: 'O_WRONLY' undeclared (first use in this function)
  mqfd_s = mq_open(qname, O_WRONLY | O_CREAT | O_EXCL | O_NONBLOCK, S_IRWXU , NULL);
                          ^~~~~~~~
```

O_* is declared on [fcntl.h](http://pubs.opengroup.org/onlinepubs/7908799/xsh/fcntl.h.html) so add it to src/xjadeo/mqueue.c

Tested on x86_64 glibc and x86_64 musl Voidlinux systems