### PR TITLE
Update configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@ AC_ARG_ENABLE(ltc,         AC_HELP_STRING([--disable-ltc], [disable LTC sync sup
 AC_ARG_ENABLE(midi,        AC_HELP_STRING([--disable-midi], [Do not build any of the MIDI drivers (default:on)]))
 AC_ARG_ENABLE(portmidi,    AC_HELP_STRING([--disable-portmidi], [disable portmidi support (default:auto)]))
 AC_ARG_ENABLE(alsamidi,    AC_HELP_STRING([--disable-alsamidi], [disable alsamidi support (default:auto)]))
-AC_ARG_ENABLE(embed-font,  AC_HELP_STRING([--embed-font], [include OnScreenDisplay font in binary (default: off)]))
+AC_ARG_ENABLE(embed-font,  AC_HELP_STRING([--enable-embed-font], [include OnScreenDisplay font in binary (default: off)]))
 AC_ARG_ENABLE(qtgui,       AC_HELP_STRING([--enable-qtgui],[Build the Qt GUI controller (default:off)]))
 AC_ARG_WITH(qt4prefix,     AS_HELP_STRING([--with-qt4prefix], [prefix for Qt4 installation, e.g. "/usr/lib/qt4"]), qt4prefix="$withval", qt4prefix="")
 AC_ARG_WITH(qmakeargs,     AS_HELP_STRING([--with-qmakeargs], [specify custom qmake arguments]), qmakeargs="$withval", qmakeargs="")


### PR DESCRIPTION
config --help tells about --embed-font but when this option is given it fails, looking at the code the right option seems --enable-embed-font, so this commit changes the --help output to reflect the right option. 

Amazing work!