### PR TITLE
osc controls to modify video scale and projection warping in realtime…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ AC_ARG_ENABLE(qtgui,       AC_HELP_STRING([--enable-qtgui],[Build the Qt GUI con
 AC_ARG_WITH(qt4prefix,     AS_HELP_STRING([--with-qt4prefix], [prefix for Qt4 installation, e.g. "/usr/lib/qt4"]), qt4prefix="$withval", qt4prefix="")
 AC_ARG_WITH(qmakeargs,     AS_HELP_STRING([--with-qmakeargs], [specify custom qmake arguments]), qmakeargs="$withval", qmakeargs="")
 AC_ARG_ENABLE(contrib,     AC_HELP_STRING([--enable-contrib], [Compile and install code in contrib folder (default:off)]))
+AC_ARG_ENABLE(warp,        AC_HELP_STRING([--enable-warp], [enable scale and projection warping (opengl only) - experimental - DO NOT USE]))
 AC_ARG_ENABLE(timescale,   AC_HELP_STRING([--enable-timescale], [enable time-mapping/loop-playback support - experimental - DO NOT USE]))
 AC_ARG_ENABLE(framecrop,   AC_HELP_STRING([--enable-framecrop], [hardcoded frame cropping - experimental - DO NOT USE]))
 AC_ARG_ENABLE(weakjack,    AC_HELP_STRING([--enable-weakjack], [load libjack at runtime (weak linking -- always enabled on OSX and Windows)]))
@@ -167,6 +168,7 @@ AH_TEMPLATE([DND], [enable xjadeo x11/glx drag and drop])
 AH_TEMPLATE([XDLG], [enable xjadeo x11/glx context menu])
 AH_TEMPLATE([XFIB], [enable xjadeo x11 file browser])
 AH_TEMPLATE([COLOREQ], [enable XV and imlib2 color equalizer])
+AH_TEMPLATE([WARP], [enable dynamic projection warping, only opengl supported])
 AH_TEMPLATE([TIMEMAP], [enable dynamic time scaling])
 AH_TEMPLATE([CROPIMG], [enable frame cropping])
 AH_TEMPLATE([DRAW_CROSS], [paint a X on screen when unable to decode or display a frame.])
@@ -180,6 +182,10 @@ AC_DEFINE(XDLG)
 AC_DEFINE(XFIB)
 AC_DEFINE(DRAW_CROSS)
 AC_DEFINE(COLOREQ)
+
+if test "x$enable_warp" = "xyes"; then
+	AC_DEFINE(WARP)
+fi
 
 if test "x$enable_timescale" != "xyes"; then
 	AC_DEFINE(TIMEMAP)

--- a/src/xjadeo/homography.h
+++ b/src/xjadeo/homography.h
@@ -1,0 +1,129 @@
+/*
+ * homography.h
+ *
+ *  based on code from arturo castro
+ * 
+ *
+ */
+#ifndef XJ_HOMOGRAPHY_H
+#define XJ_HOMOGRAPHY_H
+
+#ifdef HAVE_GL
+
+#ifdef __APPLE__
+#include "OpenGL/glu.h"
+#else
+#include <GL/glu.h>
+#endif
+
+
+typedef struct {
+	double x;
+	double y;
+} Point;
+
+
+void gaussian_elimination(double *input, int n){
+	// ported to c from pseudocode in
+	// http://en.wikipedia.org/wiki/Gaussian_elimination
+
+	double * A = input;
+	int i = 0;
+	int j = 0;
+	int m = n-1;
+	while (i < m && j < n){
+	  // Find pivot in column j, starting in row i:
+	  int maxi = i;
+	  for(int k = i+1; k<m; k++){
+	    if(fabs(A[k*n+j]) > fabs(A[maxi*n+j])){
+	      maxi = k;
+	    }
+	  }
+	  if (A[maxi*n+j] != 0){
+	    //swap rows i and maxi, but do not change the value of i
+		if(i!=maxi)
+		for(int k=0;k<n;k++){
+			GLfloat aux = A[i*n+k];
+			A[i*n+k]=A[maxi*n+k];
+			A[maxi*n+k]=aux;
+		}
+	    //Now A[i,j] will contain the old value of A[maxi,j].
+	    //divide each entry in row i by A[i,j]
+		double A_ij=A[i*n+j];
+		for(int k=0;k<n;k++){
+			A[i*n+k]/=A_ij;
+		}
+	    //Now A[i,j] will have the value 1.
+	    for(int u = i+1; u< m; u++){
+    		//subtract A[u,j] * row i from row u
+	    	double A_uj = A[u*n+j];
+	    	for(int k=0;k<n;k++){
+	    		A[u*n+k]-=A_uj*A[i*n+k];
+	    	}
+	      //Now A[u,j] will be 0, since A[u,j] - A[i,j] * A[u,j] = A[u,j] - 1 * A[u,j] = 0.
+	    }
+
+	    i++;
+	  }
+	  j++;
+	}
+
+	//back substitution
+	for(int i=m-2;i>=0;i--){
+		for(int j=i+1;j<n-1;j++){
+			A[i*n+m]-=A[i*n+j]*A[j*n+m];
+			//A[i*n+j]=0;
+		}
+	}
+}
+
+void findHomography(Point src[4], Point dst[4], GLfloat homography[16]){
+
+	// create the equation system to be solved
+	//
+	// from: Multiple View Geometry in Computer Vision 2ed
+	//       Hartley R. and Zisserman A.
+	//
+	// x' = xH
+	// where H is the homography: a 4 by 4 matrix
+	// that transformed to inhomogeneous coordinates for each point
+	// gives the following equations for each point:
+	//
+	// x' * (h31*x + h32*y + h33) = h11*x + h12*y + h13
+	// y' * (h31*x + h32*y + h33) = h21*x + h22*y + h23
+	//
+	// as the homography is scale independent we can let h33 be 1 (indeed any of the terms)
+	// so for 4 points we have 8 equations for 8 terms to solve: h11 - h32
+	// after ordering the terms it gives the following matrix
+	// that can be solved with gaussian elimination:
+
+	double P[8][9]={
+			{-src[0].x, -src[0].y, -1,   0,   0,  0, src[0].x*dst[0].x, src[0].y*dst[0].x, -dst[0].x }, // h11
+			{  0,   0,  0, -src[0].x, -src[0].y, -1, src[0].x*dst[0].y, src[0].y*dst[0].y, -dst[0].y }, // h12
+
+			{-src[1].x, -src[1].y, -1,   0,   0,  0, src[1].x*dst[1].x, src[1].y*dst[1].x, -dst[1].x }, // h13
+		    {  0,   0,  0, -src[1].x, -src[1].y, -1, src[1].x*dst[1].y, src[1].y*dst[1].y, -dst[1].y }, // h21
+
+			{-src[2].x, -src[2].y, -1,   0,   0,  0, src[2].x*dst[2].x, src[2].y*dst[2].x, -dst[2].x }, // h22
+		    {  0,   0,  0, -src[2].x, -src[2].y, -1, src[2].x*dst[2].y, src[2].y*dst[2].y, -dst[2].y }, // h23
+
+			{-src[3].x, -src[3].y, -1,   0,   0,  0, src[3].x*dst[3].x, src[3].y*dst[3].x, -dst[3].x }, // h31
+		    {  0,   0,  0, -src[3].x, -src[3].y, -1, src[3].x*dst[3].y, src[3].y*dst[3].y, -dst[3].y }, // h32
+	};
+
+	gaussian_elimination(&P[0][0],9);
+
+	// gaussian elimination gives the results of the equation system
+	// in the last column of the original matrix.
+	// opengl needs the transposed 4x4 matrix:
+	double aux_H[]={ P[0][8],P[3][8],0,P[6][8], // h11  h21 0 h31
+					P[1][8],P[4][8],0,P[7][8], // h12  h22 0 h32
+					0      ,      0,0,0,       // 0    0   0 0
+					P[2][8],P[5][8],0,1};      // h13  h23 0 h33
+
+	for(int i=0;i<16;i++) homography[i] = (GLfloat)aux_H[i];
+}
+#endif
+#endif // XJ_HOMOGRAPHY_H
+
+

--- a/src/xjadeo/xjadeo.c
+++ b/src/xjadeo/xjadeo.c
@@ -104,6 +104,13 @@ uint64_t    osd_vtc_oob;
 //------------------------------------------------
 // globals
 //------------------------------------------------
+#ifdef WARP
+//osc scale modification
+double display_scale_x_modifier = 1;
+double display_scale_y_modifier = 1;
+double display_deform_corners[8]= {0};
+int recalculate_homography = 1; // we need to calculte it the first time, then only recalculate when corresponding osc messages arrive
+#endif
 
 #ifdef TIMEMAP
 int64_t timeoffset = 0;

--- a/src/xjadeo/xjosc.c
+++ b/src/xjadeo/xjosc.c
@@ -55,6 +55,13 @@ extern int midi_clkadj;
 extern char midiid[32];
 #endif
 
+#ifdef WARP
+extern double display_scale_x_modifier;
+extern double display_scale_y_modifier;
+extern double display_deform_corners[8];
+extern int recalculate_homography;
+#endif
+
 #ifdef TIMEMAP
 extern int64_t timeoffset;
 extern double  timescale;
@@ -137,6 +144,87 @@ static int oscb_midiconnect (const char *path, const char *types, lo_arg **argv,
 static int oscb_mididisconnect (const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data){
 #ifdef HAVE_MIDI
   midi_close();
+#endif
+  return(0);
+}
+#endif
+
+#if defined WARP || defined OSC_DOC_ALL
+static int oscb_xscale (const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data){
+#ifdef WARP
+  if (want_verbose) fprintf(stderr, "OSC: %s <- f:%f\n", path, argv[0]->f);
+  display_scale_x_modifier=argv[0]->f;
+  force_redraw=1;
+#endif
+  return(0);
+}
+
+static int oscb_yscale (const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data){
+#ifdef WARP
+  if (want_verbose) fprintf(stderr, "OSC: %s <- f:%f\n", path, argv[0]->f);
+  display_scale_y_modifier=argv[0]->f;
+  force_redraw=1;
+#endif
+  return(0);
+}
+
+static int oscb_corners (const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data){
+#ifdef WARP
+  if (want_verbose) fprintf(stderr, "OSC: %s <- vec8:%f,%f,%f,%f,%f,%f,%f,%f \n", path, argv[0]->f, argv[1]->f, argv[2]->f, argv[3]->f, argv[4]->f, argv[5]->f, argv[6]->f, argv[7]->f);
+  for (size_t i = 0; i < 8; i++)
+  {
+   display_deform_corners[i]=argv[i]->f;
+  }
+  force_redraw=1;
+  recalculate_homography=1;
+#endif
+  return(0);
+}
+
+static int oscb_corner1 (const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data){
+#ifdef WARP
+  if (want_verbose) fprintf(stderr, "OSC: %s <- vec2:%f,%f \n", path, argv[0]->f, argv[1]->f);
+  
+   display_deform_corners[0]=argv[0]->f;
+   display_deform_corners[1]=argv[1]->f;
+  force_redraw=1;
+  recalculate_homography=1;
+#endif
+  return(0);
+}
+
+static int oscb_corner2 (const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data){
+#ifdef WARP
+  if (want_verbose) fprintf(stderr, "OSC: %s <- vec2:%f,%f \n", path, argv[0]->f, argv[1]->f);
+  
+   display_deform_corners[2]=-argv[0]->f;
+   display_deform_corners[3]=argv[1]->f;
+  force_redraw=1;
+  recalculate_homography=1;
+#endif
+  return(0);
+}
+
+static int oscb_corner3 (const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data){
+#ifdef WARP
+  if (want_verbose) fprintf(stderr, "OSC: %s <- vec2:%f,%f \n", path, argv[0]->f, argv[1]->f);
+  
+   display_deform_corners[4]=argv[0]->f;
+   display_deform_corners[5]=argv[1]->f;
+  force_redraw=1;
+  recalculate_homography=1;
+#endif
+  return(0);
+}
+
+static int oscb_corner4(const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data){
+#ifdef WARP
+  if (want_verbose) fprintf(stderr, "OSC: %s <- vec2:%f,%f \n", path, argv[0]->f, argv[1]->f);
+  
+   display_deform_corners[6]=argv[0]->f;
+   display_deform_corners[7]=argv[1]->f;
+  force_redraw=1;
+  recalculate_homography=1;
 #endif
   return(0);
 }
@@ -318,6 +406,16 @@ static struct osc_command OSCC[] = {
   // HAVE_MIDI
   {"/jadeo/midi/connect", "s", &oscb_midiconnect, "Get sync from MTC (MIDI Time Code). The parameter specifies the midi-port to connect to. (-m, -d, midi connect)"},
   {"/jadeo/midi/disconnect", "", &oscb_mididisconnect, "Close the MIDI device (midi disconnect)"},
+#endif
+
+#if defined WARP || defined OSC_DOC_ALL
+  {"/jadeo/art/xscale", "f", &oscb_xscale, "Modify x scale of the video"},
+  {"/jadeo/art/yscale", "f", &oscb_yscale, "Modify y scale of the video"},
+  {"/jadeo/art/corners", "ffffffff", &oscb_corners, "Modify corner deformation, all corners at one"},
+  {"/jadeo/art/corner1", "ff", &oscb_corner1, "Modify corner deformation by corner number"},
+  {"/jadeo/art/corner2", "ff", &oscb_corner2, "Modify corner deformation by corner number"},
+  {"/jadeo/art/corner3", "ff", &oscb_corner3, "Modify corner deformation by corner number"},
+  {"/jadeo/art/corner4", "ff", &oscb_corner4, "Modify corner deformation by corner number"},
 #endif
 
 #if defined CROPIMG || defined OSC_DOC_ALL


### PR DESCRIPTION
Finally i implemented scale modifying opengl vertex position and  perspective projection through homography calculation and applying it to the opengl matrix, (should be perspective correct).

I created the following controls (osc only for the moment):

/jadeo/art/xscale f  "modify the x scale of the video, 1.0 = no change, positive to scale up, negative down"
/jadeo/art/yscale f  "modify the y scale of the video"

/jadeo/art/corners (8 floats) "x,y,x,y,x,y,x,y corner value to add to each "
(that's why i have created also individual corner controls, i encountered in some softwares is not easy to work with such array, easier with 2 float arrays) 

/jadeo/art/corner1 ff "x,y corner 1, displacement, 0= no change"
/jadeo/art/corner2 ff "x,y corner 2, displacement, 0= no change"
/jadeo/art/corner3 ff "x,y corner 3, displacement, 0= no change"
/jadeo/art/corner4 ff "x,y corner 4, displacement, 0= no change"

They are activated with a new configure option --enable-warp, i have put all my new code under '#ifdef WARP' and not modified anything outside that