### PR TITLE
Xinerama support to choose startup monitor (opengl only)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,7 @@ AC_ARG_ENABLE(contrib,     AC_HELP_STRING([--enable-contrib], [Compile and insta
 AC_ARG_ENABLE(timescale,   AC_HELP_STRING([--enable-timescale], [enable time-mapping/loop-playback support - experimental - DO NOT USE]))
 AC_ARG_ENABLE(framecrop,   AC_HELP_STRING([--enable-framecrop], [hardcoded frame cropping - experimental - DO NOT USE]))
 AC_ARG_ENABLE(weakjack,    AC_HELP_STRING([--enable-weakjack], [load libjack at runtime (weak linking -- always enabled on OSX and Windows)]))
+AC_ARG_ENABLE(xinerama,    AC_HELP_STRING([--enable-xinerama],[Enable xinerama support.]))
 
 
 LIBPREF=lib
@@ -139,6 +140,7 @@ AH_TEMPLATE([HAVE_SDL], [Define as 1 if  you have the SDL toolkit (linux,netbsd,
 AH_TEMPLATE([HAVE_LIBXV], [Video Output: XVideo support (linux,netbsd)])
 AH_TEMPLATE([HAVE_IMLIB2], [Video Output: plain old imlib2 (linux,netbsd)])
 AH_TEMPLATE([IMLIB2RGBA], [Define for RGBA32 imlib2 (not RGB24)])
+AH_TEMPLATE([HAVE_LIBXINERAMA], [Define for Xinerama support])
 
 dnl MTC sync
 AH_TEMPLATE([HAVE_MIDI], [general MIDI (MTC) support])
@@ -258,6 +260,10 @@ AS_IF([test -z "$PLATFORM_OSX$PLATFORM_WINDOWS"], [
 	PKG_CHECK_MODULES(XPM, xpm, ,
 		AC_MSG_ERROR([Xpm support is mandatory on this platform - install libxpm development package.]))
 ])
+
+if test "x$enable_xinerama" = "xyes" ; then
+    PKG_CHECK_MODULES(DPY_XINERAMA, xinerama, [AC_DEFINE(HAVE_LIBXINERAMA) XV_LIBS="$XV_LIBS -lXinerama" HAVE_LIBXINERAMA=1 ], [])
+fi
 
 if test "x$enable_xv" != "xno"; then
 	AC_CHECK_LIB(Xv, XvQueryAdaptors, [AC_DEFINE(HAVE_LIBXV) XV_LIBS="$XV_LIBS -lXv" HAVE_LIBXV=1 ], [], $X_LIBS)
@@ -503,6 +509,7 @@ fi
 
 if test -n "$HAVE_GL"; then RPT_OPENGL="yes"; else RPT_OPENGL="not avail."; fi
 if test -n "$HAVE_LIBXV"; then RPT_LIBXV="yes"; else RPT_LIBXV="not avail."; fi
+if test -n "$HAVE_LIBXINERAMA"; then RPT_LIBXINERAMA="yes"; else RPT_LIBXINERAMA="no."; fi
 if test -n "$HAVE_IMLIB2"; then RPT_IMLIB2="yes"; else RPT_IMLIB2="not avail."; fi
 if test -n "$PLATFORM_OSX"; then RPT_MACOSX="yes"; else RPT_MACOSX="not avail."; fi
 if test -n "$HAVE_SDL"; then RPT_SDL="yes"; else RPT_SDL="not avail."; fi
@@ -526,6 +533,7 @@ AC_MSG_NOTICE([
 
  Video Displays
    - openGL:         $RPT_OPENGL
+   - libxinerama:    $RPT_LIBXINERAMA
    - libxv:          $RPT_LIBXV
    - libx11/imlib2:  $RPT_IMLIB2
    - mac/quartz:     $RPT_MACOSX

--- a/src/xjadeo/main.c
+++ b/src/xjadeo/main.c
@@ -172,6 +172,9 @@ int want_nosplash =0;	/* --nosplash */
 int want_noindex =0;	/* --noindex */
 int start_ontop =0;	/* --ontop // -a */
 int start_fullscreen =0;/* --fullscreen // -s */
+#ifdef HAVE_LIBXINERAMA
+int start_screen = -1; /* --start-screen // -X  # -1 auto*/
+#endif
 int want_letterbox =1;  /* --letterbox -b */
 int want_dropframes =0; /* --dropframes -N  -- force using drop-frame timecode */
 int want_autodrop =1;   /* --nodropframes -n (hidden option) -- allow using drop-frame timecode */
@@ -277,6 +280,9 @@ static struct option const long_options[] =
 #endif
 	{"no-splash",           no_argument, 0,       'S'},
 	{"fullscreen",          no_argument, 0,       's'},
+#ifdef HAVE_LIBXINERAMA
+	{"start-screen",        required_argument, 0, 'X'},
+#endif
 	{"ttf-font",            required_argument, 0, 'T'},
 #ifdef JACK_SESSION
 	{"uuid",                required_argument, 0, 'U'},
@@ -329,6 +335,9 @@ decode_switches (int argc, char **argv)
 		"r:" /* --rc */
 		"S"  /* nosplash */
 		"s"  /* start in full-screen mode */
+#ifdef HAVE_LIBXINERAMA
+		"X:"  /* --start-screen */
+#endif
 		"T:" /* ttf-font */
 #ifdef JACK_SESSION
 		"U:" /* --uuid */
@@ -435,6 +444,11 @@ decode_switches (int argc, char **argv)
 			case 's':
 				start_fullscreen = 1;
 				break;
+#ifdef HAVE_LIBXINERAMA
+			case 'X':
+				start_screen = atoi(optarg);
+				break;
+#endif
 			case 'T':
 				strcpy(OSD_fontfile, optarg);
 				break;
@@ -632,6 +646,10 @@ usage (int status)
 " -r <file>, --rc <file>    Specify a custom configuration file to load.\n"
 " -S, --no-splash           Skip the on screen display startup sequence.\n"
 " -s, --fullscreen          Start xjadeo in full screen mode.\n"
+#ifdef HAVE_LIBXINERAMA
+" -X <int>, --start-screen <int>"
+"                           Choose scren to start xjadeo in\n"
+#endif
 " -T <file>, --ttf-file <file>\n"
 "                           path to .ttf font for on screen display\n"
 " -U, --uuid                specify JACK SESSION UUID.\n"


### PR DESCRIPTION
Since for our project we need to run multiple instances of xjadeo in multiple monitor, i added a option to check for multiple monitors an be able to choose on what monitor xjadeo window is positioned on startup. If no --start-monitor is given original behavior ir respected, in my case opening the window in the monitor the mouse pointer is at. If the --start-monitor option is given the window gets placed in the  coordinates of the monitor that xinerama provides. At the moment is implemented only for opengl, but i think it could be implemented for other X flavours. The option can be enabled at configure time with --enable-xinerama, and works well in my tests with the fullscreen option, so one can automate full screen startup in multiple monitors. 


https://github.com/stagesoft/stagesoft-project