### PR TITLE
Guard against some deprecated ffmpeg functionality

### DIFF
--- a/src/xjadeo/ffcompat.h
+++ b/src/xjadeo/ffcompat.h
@@ -117,4 +117,16 @@ static inline AVFrame *av_frame_alloc()
 }
 #endif
 
+static inline void
+register_codecs_compat ()
+{
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
+  av_register_all();
+#endif
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 10, 100)
+  avcodec_register_all();
+#endif
+}
+
+
 #endif /* FFCOMPAT_H */

--- a/src/xjadeo/xjadeo.c
+++ b/src/xjadeo/xjadeo.c
@@ -484,7 +484,11 @@ static uint64_t parse_pts_from_frame (AVFrame *f) {
 #endif
 
 	if (pts == AV_NOPTS_VALUE) {
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57, 61, 100)
 		pts = f->pkt_pts;
+#else
+		pts = f->pts;
+#endif
 		if (pts != AV_NOPTS_VALUE) {
 			if (!(pts_warn & 2) && !want_quiet)
 				fprintf(stderr, "Used PTS from packet instead frame's PTS.\n");

--- a/src/xjadeo/xjadeo.c
+++ b/src/xjadeo/xjadeo.c
@@ -448,11 +448,10 @@ void init_moviebuffer (void) {
 }
 
 void avinit (void) {
-	av_register_all ();
+	register_codecs_compat();
 #if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(53, 20, 0)
 	avcodec_init ();
 #endif
-	avcodec_register_all ();
 	if (!want_avverbose) av_log_set_level (AV_LOG_QUIET);
 }
 

--- a/src/xjadeo/xjadeo.c
+++ b/src/xjadeo/xjadeo.c
@@ -1303,7 +1303,11 @@ int open_movie (char* file_name) {
 
 	/* Find the first video stream */
 	for (i = 0; i < pFormatCtx->nb_streams; ++i)
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(57, 33, 100)
 		if (pFormatCtx->streams[i]->codec->codec_type == AVMEDIA_TYPE_VIDEO) {
+#else
+		if (pFormatCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+#endif
 			videoStream = i;
 			break;
 		}
@@ -1399,7 +1403,11 @@ int open_movie (char* file_name) {
 	}
 
 	// Get a pointer to the codec context for the video stream
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(57, 33, 100)
 	pCodecCtx=pFormatCtx->streams[videoStream]->codec;
+#else
+	pCodecCtx=pFormatCtx->streams[videoStream]->codecpar;
+#endif
 
 	if (!want_quiet) {
 		fprintf(stdout, "frame rate: %g\n", framerate);
@@ -1421,8 +1429,13 @@ int open_movie (char* file_name) {
 	float sample_aspect = 1.0;
 	if (av_stream->sample_aspect_ratio.num)
 		sample_aspect = av_q2d (av_stream->sample_aspect_ratio);
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(57, 33, 100)
 	else if (av_stream->codec->sample_aspect_ratio.num)
 		sample_aspect = av_q2d (av_stream->codec->sample_aspect_ratio);
+#else
+	else if (av_stream->codecpar->sample_aspect_ratio.num)
+		sample_aspect = av_q2d (av_stream->codecpar->sample_aspect_ratio);
+#endif
 	else
 		sample_aspect = 1.0;
 
@@ -1516,9 +1529,15 @@ int open_movie (char* file_name) {
 	if (av_stream->sample_aspect_ratio.num)
 		sprintf(OSD_nfo_geo[2], "SAR: %d : %d",
 				av_stream->sample_aspect_ratio.num, av_stream->sample_aspect_ratio.den);
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(57, 33, 100)
 	else if (av_stream->codec->sample_aspect_ratio.num)
 		sprintf(OSD_nfo_geo[2], "SAR: %d : %d",
 				av_stream->codec->sample_aspect_ratio.num, av_stream->codec->sample_aspect_ratio.den);
+#else
+	else if (av_stream->codecpar->sample_aspect_ratio.num)
+		sprintf(OSD_nfo_geo[2], "SAR: %d : %d",
+				av_stream->codecpar->sample_aspect_ratio.num, av_stream->codecpar->sample_aspect_ratio.den);
+#endif
 	else
 		sprintf(OSD_nfo_geo[2], "SAR: unknown (1 : 1)");
 


### PR DESCRIPTION
This PR attempts to guard against some deprecated ffmpeg functionality.

However, https://github.com/x42/xjadeo/commit/aade82a427d4839e8db3816effcef16467e80dd6 does not work as intended, as it leads to: 

```
xjadeo.c:1340:33: error: invalid initializer
xjadeo.c:1409:18: warning: assignment to ‘AVCodecContext *’ from incompatible pointer type ‘AVCodecParameters *’ [-Wincompatible-pointer-types]
 1409 |         pCodecCtx=pFormatCtx->streams[videoStream]->codecpar;
      |                  ^
```

Unfortunately I do not know how to do this any better. Suggestions welcome!

This does not yet provide compatibility with ffmpeg >= 5 though (also) for the same reasons as mentioned in https://github.com/x42/harvid/issues/8