### PR TITLE
wrap-around/loop: fix invalid frames

### DIFF
--- a/src/xjadeo/xjadeo.c
+++ b/src/xjadeo/xjadeo.c
@@ -328,7 +328,7 @@ void event_loop (void) {
 #ifdef TIMEMAP
 		newFrame = floor ((double)newFrame * timescale) + timeoffset;
 		// TODO: calc newFrames/frames instead of while-loop
-		while (newFrame > frames && wraparound && frames != 0)
+		while (newFrame >= frames && wraparound && frames != 0)
 			newFrame -= frames;
 		while (newFrame < 0 && wraparound && frames != 0)
 			newFrame += frames;

--- a/src/xjadeo/xjadeo.c
+++ b/src/xjadeo/xjadeo.c
@@ -327,7 +327,7 @@ void event_loop (void) {
 
 #ifdef TIMEMAP
 		newFrame = floor ((double)newFrame * timescale) + timeoffset;
-		if(wraparound)
+		if(wraparound && frames != 0)
 		{
 			newFrame %= frames;
 			if(newFrame < 0)

--- a/src/xjadeo/xjadeo.c
+++ b/src/xjadeo/xjadeo.c
@@ -327,11 +327,12 @@ void event_loop (void) {
 
 #ifdef TIMEMAP
 		newFrame = floor ((double)newFrame * timescale) + timeoffset;
-		// TODO: calc newFrames/frames instead of while-loop
-		while (newFrame >= frames && wraparound && frames != 0)
-			newFrame -= frames;
-		while (newFrame < 0 && wraparound && frames != 0)
-			newFrame += frames;
+		if(wraparound)
+		{
+			newFrame %= frames;
+			if(newFrame < 0)
+				newFrame += frames;
+		}
 #endif
 
 		offFrame = newFrame + ts_offset;


### PR DESCRIPTION
- If loop/wrap-around is active and the current frame index is at exactly the total number of frames, there are invalid frames (XJadeo displays a black frame with a white X on top of it). The first commit contains a simple fix for this.
- The second commit contains a simplification of the frame calculation that eliminates the use of while loops by using modulo instead.

Note: I fixed this blindly (without building/testing)! Maybe you would want to confirm the fix first before putting it into the next version.